### PR TITLE
Use more verbose text for upload menu

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -678,7 +678,7 @@ Files_Texteditor.NewFileMenuPlugin = {
 		// register the new menu entry
 		menu.addMenuEntry({
 			id: 'file',
-			displayName: t('files_texteditor', 'Text file'),
+			displayName: t('files_texteditor', 'New text file'),
 			templateName: t('files_texteditor', 'New text file.txt'),
 			iconClass: 'icon-filetype-text',
 			fileType: 'file',


### PR DESCRIPTION
Change »Text file« to »New text file«. Cause it’s not upload for example.

Ref https://github.com/nextcloud/server/pull/4922

Please review @nextcloud/designers 