### PR TITLE
Render markdown files directly in public share

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -1,8 +1,9 @@
 <?php
 
+$eventDispatcher = \OC::$server->getEventDispatcher();
+
 // only load text editor if the user is logged in
 if (\OCP\User::isLoggedIn()) {
-	$eventDispatcher = \OC::$server->getEventDispatcher();
 	$eventDispatcher->addListener('OCA\Files::loadAdditionalScripts', function() {
 		OCP\Util::addStyle('files_texteditor', 'merged');
 		OCP\Util::addScript('files_texteditor', 'merged');
@@ -14,3 +15,8 @@ if (\OCP\User::isLoggedIn()) {
 	});
 }
 
+$eventDispatcher->addListener('OCA\Files_Sharing::loadAdditionalScripts', function() {
+	OC_Util::addVendorScript('core', 'marked/marked.min');
+	OCP\Util::addScript('files_texteditor', 'public-share');
+	OCP\Util::addStyle('files_texteditor', 'public-share');
+});

--- a/css/public-share.css
+++ b/css/public-share.css
@@ -1,0 +1,77 @@
+.preview {
+	max-width: 700px;
+	padding: 0px 20px !important;
+	box-sizing: border-box;
+	font-size: 18px;
+	line-height: 1.6em;
+	min-height: 440px;
+	color: #333;
+	text-align: left;
+	margin-bottom: 170px !important;
+}
+
+.preview h1,
+.preview h2,
+.preview h3 {
+	margin-top: 1em;
+}
+
+.preview h1 {
+	line-height: 1.1em;
+	margin-bottom: 1em;
+	text-align: center;
+	font-size: 3em;
+}
+
+.preview h2 {
+	line-height: 1.1em;
+	margin-bottom: .5em;
+	font-size: 2em;
+}
+
+.preview h3 {
+	line-height: 1.1em;
+	margin-bottom: .6em;
+	font-size: 1.4em;
+}
+
+.preview p,
+.preview ul,
+.preview ol,
+.preview pre {
+	margin-bottom: 17.6px;
+	line-height: 1.45em;
+}
+.preview ul,
+.preview ol {
+	padding-left: 25px;
+}
+
+.preview ul {
+	list-style-type: square;
+}
+
+.preview ul ul {
+	list-style-type: circle;
+}
+
+.preview a {
+	color: #448ac9;
+	text-decoration: none;
+}
+.preview a:hover,
+.preview a:focus,
+.preview a:active {
+	text-decoration: underline;
+}
+
+.preview em {
+	opacity: 1;
+	font-style: italic;
+}
+
+/* hide image preview during loading or if it renders fine */
+.icon-loading .text-preview,
+.preview .text-preview {
+	display: none !important;
+}

--- a/js/public-share.js
+++ b/js/public-share.js
@@ -1,0 +1,68 @@
+// FIXME: Hack for single public file view since it is not attached to the fileslist
+$(document).ready(function(){
+	if ($('#isPublic').val() &&
+		$('#mimetype').val() === 'text/markdown' &&
+		$('#filesize').val() < 524288) {
+
+		var sharingToken = $('#sharingToken').val();
+		var downloadUrl = OC.generateUrl('/s/{token}/download', {token: sharingToken});
+		var previewElement = $('#imgframe');
+		var renderer = new marked.Renderer();
+		renderer.link = function(href, title, text) {
+			try {
+				var prot = decodeURIComponent(unescape(href))
+					.replace(/[^\w:]/g, '')
+					.toLowerCase();
+			} catch (e) {
+				return '';
+			}
+
+			if (prot.indexOf('http:') !== 0 && prot.indexOf('https:') !== 0) {
+				return '';
+			}
+
+			var out = '<a href="' + href + '" rel="noreferrer noopener"';
+			if (title) {
+				out += ' title="' + title + '"';
+			}
+			out += '>' + text + '</a>';
+			return out;
+		};
+		renderer.image = function(href, title, text) {
+			if (text) {
+				return text;
+			}
+			return title;
+		};
+		renderer.blockquote = function(quote) {
+			return quote;
+		};
+
+		previewElement
+			.addClass('icon-loading')
+			.children().detach();
+
+		$.get(downloadUrl).success(function(content) {
+			previewElement
+				.removeClass('icon-loading')
+				.addClass('preview')
+				.html(DOMPurify.sanitize(
+					marked(content, {
+						renderer: renderer,
+						gfm: false,
+						breaks: false,
+						pedantic: false,
+						sanitize: true,
+						smartLists: true,
+						smartypants: false
+					}),
+					{
+						SAFE_FOR_JQUERY: true
+					}
+				));
+		}).fail(function(result){
+			previewElement
+				.removeClass('icon-loading');
+		});
+	}
+});


### PR DESCRIPTION
Renders markdown files for single share pages directly inline and uses a readable styling (instead of the squared preview image for the text file).

Looks like this then: 

![bildschirmfoto 2017-07-21 um 00 34 46](https://user-images.githubusercontent.com/245432/28441994-1b79f66a-6dae-11e7-8703-bea2a4923f46.png)
![bildschirmfoto 2017-07-21 um 00 34 54](https://user-images.githubusercontent.com/245432/28441995-1b7bbdf6-6dae-11e7-9eac-f8e8ba6e6256.png)
![bildschirmfoto 2017-07-21 um 00 03 31](https://user-images.githubusercontent.com/245432/28441996-1b7d1b9c-6dae-11e7-9662-77d598a39ffc.png)

In case the loading of the preview failed it will show the default image preview as before.