### PR TITLE
Allow using hash navigation withing the editor

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -194,9 +194,7 @@ var Files_Texteditor = {
 			OCA.Files_Texteditor.$container,
 			OCA.Files_Texteditor.file
 		);
-		if(!$('html').hasClass('ie8')) {
-			history.pushState({file:filename, dir:context.dir}, 'Editor', '#editor');
-		}
+		history.pushState({file:filename, dir:context.dir}, 'Editor', '#editor');
 	},
 
 	/**
@@ -322,11 +320,6 @@ var Files_Texteditor = {
 				} else {
 					_self.previewPluginOnChange = null;
 				}
-
-				// IE8 support
-				if(!OC.Util.hasSVGSupport()){ //replace all svg images with png images for browser that dont support svg
-					OC.Util.replaceSVG();
-				}
 			},
 			function(message){
 				// Oh dear
@@ -425,14 +418,14 @@ var Files_Texteditor = {
 	 * Binds the control events on the control bar
 	 */
 	bindControlBar: function() {
-		var self = this;
 		$('#editor_close').on('click', _.bind(this._onCloseTrigger, this));
 		$(window).resize(OCA.Files_Texteditor.setFilenameMaxLength);
-		if(!$('html').hasClass('ie8')) {
-			window.onpopstate = function () {
-				self._onCloseTrigger();
+		window.onpopstate = function () {
+			var hash = location.hash.substr(1);
+			if (hash.substr(0, 6) !== 'editor') {
+				this._onCloseTrigger();
 			}
-		}
+		}.bind(this);
 	},
 
 	/**


### PR DESCRIPTION
Don't close the texteditor as long as the has starts with `editor`

This allows the markdown app to allow for header navigation using `#editor/header`

Also cleans up some old ie8 compat logic