### PR TITLE
Fix autosave timer

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -636,8 +636,8 @@ var Files_Texteditor = {
 	 * Configure the autosave timer
 	 */
 	setupAutosave: function() {
-		clearTimeout(this.saveTimer);
-		this.saveTimer = setTimeout(OCA.Files_Texteditor._onSaveTrigger, 3000);
+		clearTimeout(OCA.Files_Texteditor.saveTimer);
+		OCA.Files_Texteditor.saveTimer = setTimeout(OCA.Files_Texteditor._onSaveTrigger, 3000);
 	},
 
 	/**


### PR DESCRIPTION
The autosave timer was not functioning properly because the timer was being incorrectly stored and could not be cleared, resulting in a save file request for every change in the editor being sent to the server.

Should fix #41 and #23.

I have not made a PR to Nextcloud before so if you need anything else from me please let me know.