### PR TITLE
Break headings in share preview to prevent overflow

### DIFF
--- a/css/public-share.css
+++ b/css/public-share.css
@@ -14,6 +14,7 @@
 .preview h2,
 .preview h3 {
 	margin-top: 1em;
+	word-wrap: break-word;
 }
 
 .preview h1 {


### PR DESCRIPTION
Before:
![screenshot from 2017-09-26 14-19-49](https://user-images.githubusercontent.com/925062/30859966-f3dd0f14-a2c5-11e7-8f3d-6a650ddc92d4.png)

After:
![screenshot from 2017-09-26 14-19-34](https://user-images.githubusercontent.com/925062/30859967-f3e088d8-a2c5-11e7-937d-1847feb78e13.png)

It’s not ideal because hyphens are missing, but hyphenation support is just very bad at the moment and hyphens: all; or auto just makes it break way worse to keep headings on one line.

Please review @nextcloud/designers 