### PR TITLE
Fix autosave timer

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -635,8 +635,8 @@ var Files_Texteditor = {
 	 * Configure the autosave timer
 	 */
 	setupAutosave: function() {
-		clearTimeout(this.saveTimer);
-		this.saveTimer = setTimeout(OCA.Files_Texteditor._onSaveTrigger, 3000);
+		clearTimeout(OCA.Files_Texteditor.saveTimer);
+		OCA.Files_Texteditor.saveTimer = setTimeout(OCA.Files_Texteditor._onSaveTrigger, 3000);
 	},
 
 	/**


### PR DESCRIPTION
Backport of #67 

The autosave timer was not functioning properly because the timer was being incorrectly stored, resulting in a save file request for every change in the editor to be sent to the server.

Signed-off-by: Vincent Van Laak <supersayu@gmail.com>