### PR TITLE
Improve rendering of Markdown

### DIFF
--- a/css/public-share.css
+++ b/css/public-share.css
@@ -1,5 +1,5 @@
 .preview {
-	max-width: 700px;
+	max-width: 810px;
 	padding: 0px 20px !important;
 	box-sizing: border-box;
 	font-size: 18px;
@@ -40,8 +40,11 @@
 .preview ul,
 .preview ol,
 .preview pre {
-	margin-bottom: 17.6px;
 	line-height: 1.45em;
+}
+.preview p,
+.preview pre {
+	margin-bottom: 17.6px;
 }
 .preview ul,
 .preview ol {
@@ -75,4 +78,10 @@
 .icon-loading .text-preview,
 .preview .text-preview {
 	display: none !important;
+}
+
+.preview code {
+	background-color: rgb(242, 242, 242);
+	border-radius: 3px;
+	padding: 0px 2px 2px 2px;
 }


### PR DESCRIPTION
* a bit wider body
* no margin below lists 
* grey background behind monospaced text

Before:

![bildschirmfoto 2018-01-23 um 13 54 03](https://user-images.githubusercontent.com/245432/35276823-fe33dc68-0044-11e8-803f-b7e6c121e748.png)

After:

![bildschirmfoto 2018-01-23 um 13 52 34](https://user-images.githubusercontent.com/245432/35276833-0282d3be-0045-11e8-81e4-e01155364fe8.png)

@nextcloud/designers Just a small improvement but I would say it's worth it :)