### PR TITLE
Fix ACE module files failing to load

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -440,6 +440,10 @@ var Files_Texteditor = {
 	 * Configure the ACE editor
 	 */
 	configureACE: function(file) {
+		ace.require('ace/config').set(
+			'basePath',
+			OC.filePath('files_texteditor', 'js', 'core/vendor/ace-builds/src-noconflict')
+		);
 		window.aceEditor = ace.edit(this.editor);
 		aceEditor.getSession().setNewLineMode("windows");
 		aceEditor.setShowPrintMargin(false);


### PR DESCRIPTION
Fixes (in master) #39, which is a regression introduced in #32

When an ACE module is loaded, if the module is not already defined, [the file that should contain the definition of the module is loaded](https://github.com/nextcloud/files_texteditor/blob/700ef96634fb04bf86d246a0ffe2009d674f05a5/js/core/vendor/ace-builds/src-noconflict/ace.js#L4146). If no explicit URL was set for the module file, the URL of the file to load is based on the module name and the path configured for the component type (`worker`, `mode` or `theme`); if no explicit path was set or the module has no special type then [the `basePath` configuration option is used instead](https://github.com/nextcloud/files_texteditor/blob/700ef96634fb04bf86d246a0ffe2009d674f05a5/js/core/vendor/ace-builds/src-noconflict/ace.js#L4098).

When the ACE editor is initialized, [by default the base path is set to the directory of the _ace.js_ file](https://github.com/nextcloud/files_texteditor/blob/700ef96634fb04bf86d246a0ffe2009d674f05a5/js/core/vendor/ace-builds/src-noconflict/ace.js#L4176-L4178). When [the JavaScript files were merged](https://github.com/nextcloud/files_texteditor/pull/32) _ace.js_ was no longer added to the page as a single script file, so the base path was no longer set, and thus the module URL was just based on its name, without a path. Due to this the URL for the _ace/ext/searchbox_ module ended being just _ext-searchbox.js_, and as such it was relative to the URL of the current page (and thus, wrong). Note, however, that [themes](https://github.com/nextcloud/files_texteditor/blob/master/js/editor.js#L457) and [syntax highlighting](https://github.com/nextcloud/files_texteditor/blob/master/js/editor.js#L534) worked fine because the needed files were explicitly added to the page.

In order to fix this the right base path had to be set in the editor configuration.

Besides _master_, this fix is needed too in the _stable12_ and _stable13_ branches. It brings back the search box, and also the syntax check in _stable12_; in _stable13_ and _master_ the syntax check is not working either since the update to ACE 1.2.8.; something for another pull request ;-)

@nextcloud/javascript 
