### PR TITLE
Do not keep FileInfoModels returned by "getModelForFile"

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -191,7 +191,7 @@ var Files_Texteditor = {
 		this.currentContext = context;
 		this.file.name = filename;
 		this.file.dir = context.dir;
-		this.fileInfoModel = context.fileList.getModelForFile(filename);
+		this.fileList = context.fileList;
 		this.loadEditor(
 			OCA.Files_Texteditor.$container,
 			OCA.Files_Texteditor.file
@@ -616,10 +616,11 @@ var Files_Texteditor = {
 		this.$container.html('').show();
 		this.unloadControlBar();
 		this.unBindVisibleActions();
-		if (this.fileInfoModel) {
-			this.fileInfoModel.set({
+		var fileInfoModel = this.fileList.getModelForFile(this.file.name);
+		if (fileInfoModel) {
+			fileInfoModel.set({
 				// temp dummy, until we can do a PROPFIND
-				etag: this.fileInfoModel.get('id') + this.file.mtime,
+				etag: fileInfoModel.get('id') + this.file.mtime,
 				mtime: this.file.mtime * 1000,
 				size: this.file.size
 			});


### PR DESCRIPTION
Fixes #73
Fixes nextcloud/server#4869
Fixes nextcloud/server#6941
Fixes nextcloud/server#7499

When a new text file is created the editor is opened, which called `getModelForFile` and stored the returned model for later use.

However, `FileInfoModel`s returned by `getModelForFile` are just temporary, and they should be used and forgotten instead of being kept. It is not guaranteed that different calls to `getModelForFile` for the same file returns the same `FileInfoModel` object, so changes in one model instance could be not known by other model instances (and their views). In fact, `getModelForFile` always returns a different model object, [except when the file of `_currentFileModel` matches the file to get the model for](https://github.com/nextcloud/server/blob/cda811b6b49d2925fa044b5c391cea27a9da8724/apps/files/js/filelist.js#L445-L447).

[`_currentFileModel` is set when the details view is updated to display certain file](https://github.com/nextcloud/server/blob/cda811b6b49d2925fa044b5c391cea27a9da8724/apps/files/js/filelist.js#L540). It turns out that when any file is created the file list is scrolled to the new file and the details view for that file is opened. However, although the call to `scrollTo` happens before opening the editor [the opening of the details view is defered](https://github.com/nextcloud/server/blob/cda811b6b49d2925fa044b5c391cea27a9da8724/apps/files/js/filelist.js#L2731-L2733), so it happens after the editor is opened. Thus, when a new text file was created, a `FileInfoModel` was created and kept by the editor and, then, a new `FileInfoModel` was created and stored in `_currentFileModel`.

The model stored by the editor is only used when the editor is closed. When that happens, the model is updated with the file properties changed by the editor (size, modification time). [Changing a model causes the row for its file to be updated](https://github.com/nextcloud/server/blob/cda811b6b49d2925fa044b5c391cea27a9da8724/apps/files/js/filelist.js#L464) in the file list. And when a row is updated [the old row is removed from the file list and a new one is added to replace it](https://github.com/nextcloud/server/blob/cda811b6b49d2925fa044b5c391cea27a9da8724/apps/files/js/filelist.js#L2223-L2226). But when there are several model instances for the same file and one of the instances is changed... the rest of instances do not know that the other instance was changed and that the row was updated! And here come the problems.

When the editor is closed its model instance is changed. But remember that there was another model instance around, the one created when the details view was shown, which was stored in `_currentFileModel` and that does not know that the file row was updated. See where this is going? Now, when `getModelForFile` is called again for that file the returned model is the one stored in `_currentFileModel`; if that model is then changed it will update the row... but it will try to remove the row that was already removed, so the current file row is not touched, and then it will add a new one, which will cause a duplicated entry to appear. Yay, you made it to the end of the explanation, congratulations :-P

This pull request modifies the text editor to use and forget the `FileInfoModel` instead of keeping it, which fixes the duplicated entries in the file list after creating a text file. The real fix would have to be done in the file list to ensure that `getModelForFile` always returns the same model instance for each file, but whatever the fix it should be backported to _stable12_ and _stable13_, and the one here is easier to backport ;-) (I have already made the backports, I will send them once this one is merged)
