### PR TITLE
Do not sanitize markdown output twice

### DIFF
--- a/js/public-share.js
+++ b/js/public-share.js
@@ -56,7 +56,6 @@ $(document).ready(function(){
 						gfm: false,
 						breaks: false,
 						pedantic: false,
-						sanitize: true,
 						smartLists: true,
 						smartypants: false
 					}),


### PR DESCRIPTION
Followup to #48 

Noticed the following inline HTML is otherwise escaped twice (by `marked` and the `DOMPurify`):


```

Text

<details>
<summary>Abc</summary>

Long text
abc
def
</details>
```

Before:
![bildschirmfoto 2018-05-16 um 16 52 13](https://user-images.githubusercontent.com/245432/40124747-86bf29f6-5929-11e8-8196-a6aa95b33257.png)


After:
![bildschirmfoto 2018-05-16 um 16 52 03](https://user-images.githubusercontent.com/245432/40124755-8a2f41ca-5929-11e8-9756-cd7906ea5796.png)
