### PR TITLE
Get fetched bytes and check for byte count into sync when showing ellipsis

### DIFF
--- a/js/public-share.js
+++ b/js/public-share.js
@@ -97,7 +97,7 @@ $(document).ready(function(){
 				.append(textDiv);
 
 			var divHeight = textDiv.height();
-			if (content.length > 50000) {
+			if (content.length > 524289) {
 				var ellipsis = $('<div/>').addClass('ellipsis');
 				ellipsis.html('(&#133;)');
 				ellipsis.appendTo('#imgframe');


### PR DESCRIPTION
Otherwise it is already shown for files that are bigger than 50kb even if the file is fully shown.