### PR TITLE
Move editor container outside of the app content

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -283,7 +283,7 @@ var Files_Texteditor = {
 			+'<div id="editor_container" class="icon-loading">'
 			+'<div id="editor_wrap"><div id="editor"></div>'
 			+'<div id="preview_wrap"><div id="preview"></div></div></div></div>');
-		$('#app-content').append(container);
+		$('#content').append(container);
 
 
 		// Get the file data


### PR DESCRIPTION
Fix https://github.com/nextcloud/files_texteditor/issues/106

This way the existing z-index will be used and the editor wrapper is put above the sidebar/appcontent