### PR TITLE
Default to preview mode when the editor is readonly 

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -293,6 +293,9 @@ export const Texteditor = {
 				if (_self.previewPlugins[file.mime]) {
 					_self.preview = container.find('#preview');
 					_self.preview.addClass(file.mime.replace('/', '-'));
+					if (window.aceEditor.getReadOnly()){
+						container.find('#editor_container').addClass('onlyPreview');
+					}
 					container.find('#editor_container').addClass('hasPreview');
 					_self.previewPluginOnChange = _.debounce(function (text, element) {
 						_self.loadPreviewPlugin(file.mime).then(function () {
@@ -383,10 +386,11 @@ export const Texteditor = {
 			return button.css('background-image', 'url("' + OC.imagePath('files_texteditor', type) + '")');
 		}.bind(this);
 
+		var readonly = window.aceEditor.getReadOnly();
 		var controls = $('<span/>').attr('id', 'preview_editor_controls');
 		controls.append(makeButton('text', t('files_texteditor', 'Edit')));
-		controls.append(makeButton('mixed', t('files_texteditor', 'Mixed'), true));
-		controls.append(makeButton('image', t('files_texteditor', 'Preview')));
+		controls.append(makeButton('mixed', t('files_texteditor', 'Mixed'), !readonly));
+		controls.append(makeButton('image', t('files_texteditor', 'Preview'), readonly));
 		$('#editor_close').after(controls);
 	},
 


### PR DESCRIPTION
cf icewind1991/files_markdown#71, the rationale is that if the file is readonly, might aswell switch by default to the preview mode (there's a small graphical glitch here, in the sense that i briefly see the code view before the display switches to preview, but that's minor)

The editor & split view panes are kept in case one wants to view the code along the document..