### PR TITLE
Darken background, adjust to new modal component

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -196,9 +196,9 @@
 	height: 100%;
 	background-color: black;
 	z-index: 3001;
-	-moz-opacity: 0.7;
-	opacity:.70;
-	filter: alpha(opacity=70);
+	-moz-opacity: .85;
+	opacity: .85;
+	filter: alpha(opacity=85);
 }
 
 small.unsaved-star {

--- a/css/style.scss
+++ b/css/style.scss
@@ -51,7 +51,7 @@
 	z-index: 9999;
 	overflow: hidden;
 	background-color: #fff;
-	border-radius: 3px;
+	border-radius: var(--border-radius-large);
 	box-sizing: border-box;
 }
 


### PR DESCRIPTION
Adjust to the 85% black we also will use for the new Modal, ref https://github.com/nextcloud/nextcloud-vue/pull/300

Please review @nextcloud/designers 
Before & after:
![text editor background before](https://user-images.githubusercontent.com/925062/54222561-f46d7080-44f5-11e9-9441-9747157d4fae.png)
![text editor background](https://user-images.githubusercontent.com/925062/54222562-f46d7080-44f5-11e9-9eee-88ba0bd8973c.png)
