### PR TITLE
Fix for Searchbox (CTRL + F)

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -190,6 +190,7 @@ export const Texteditor = {
 		this.file.dir = context.dir;
 		this.fileList = context.fileList;
 		importAce().then((_ace) => {
+			require('brace/ext/searchbox');
 			ace = _ace;
 			this.loadEditor(
 				Texteditor.$container,


### PR DESCRIPTION
Fix for Search / Replace (CTRL + F / CTRL + H); adds brace package require call for enabling the search box.  
  
Fix for #189 / #184
  
[More info here](https://github.com/nextcloud/files_texteditor/issues/184#issuecomment-597246481).  
  
I have no idea on how to backport / rebuild the tag versions builds to include this on them. 