### PR TITLE
use escape-html

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -1,5 +1,6 @@
 import {getSyntaxMode} from './SyntaxMode';
 import importAce from './ImportAce';
+import escapeHTML from 'escape-html'
 
 /** @type array[] supportedMimeTypes */
 const supportedMimeTypes = require('./supported_mimetypes.json');

--- a/package-lock.json
+++ b/package-lock.json
@@ -2651,9 +2651,15 @@
       }
     },
     "escalade": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.2.tgz",
-      "integrity": "sha512-gPYAU37hYCUhW5euPeR+Y74F7BL+IBsV93j5cvGriSaD1aG6MGsqsV1yamRdrWrb2j3aiZvb0X+UBOWpx3JWtQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.0.tgz",
+      "integrity": "sha512-mAk+hPSO8fLDkhV7V0dXazH5pDc6MrjBTPyD3VeKzxnVFjH1MIxbCdqGZB9O8+EwWakZs3ZCbDS4IpRt79V1ig==",
+      "dev": true
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "dev": true
     },
     "escape-string-regexp": {
@@ -3704,9 +3710,9 @@
       }
     },
     "marked": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.0.tgz",
-      "integrity": "sha512-MyUe+T/Pw4TZufHkzAfDj6HarCBWia2y27/bhuYkTaiUnfDYFnCP3KUN+9oM7Wi6JA2rymtVYbQu3spE0GCmxQ=="
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
+      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw=="
     },
     "md5.js": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "babel-loader": "^8.1.0",
     "clean-webpack-plugin": "^3.0.0",
     "css-loader": "^4.3.0",
+    "escape-html": "^1.0.3",
     "file-loader": "^6.1.0",
     "promise-loader": "^1.0.0",
     "style-loader": "^1.2.1",
@@ -27,6 +28,6 @@
   },
   "dependencies": {
     "brace": "^0.11.1",
-    "marked": "^0.8.0"
+    "marked": "^0.8.2"
   }
 }


### PR DESCRIPTION
otherwise the editor is broken with nc no longer adding a global escapeHTML