### PR TITLE
fix: wrong translation string

### DIFF
--- a/lib/Controller/FileHandlingController.php
+++ b/lib/Controller/FileHandlingController.php
@@ -84,7 +84,7 @@ class FileHandlingController extends Controller {
 				$file = $this->userFolder->get($path);
 
 				if ($file instanceof Folder) {
-					return new DataResponse(['message' => $this->l->t('You cannot open a folder.')], Http::STATUS_BAD_REQUEST);
+					return new DataResponse(['message' => $this->l->t('You cannot open a folder')], Http::STATUS_BAD_REQUEST);
 				}
 
 				// default of 4MB


### PR DESCRIPTION
Remove dot at end of translation string to match PublicFileHandlingController and only have one translation string.

Currently we have:

https://github.com/nextcloud/files_texteditor/blob/0d13b98bd00faedd1da3e98aac0cfd573f32cbd0/lib/Controller/PublicFileHandlingController.php#L96

https://github.com/nextcloud/files_texteditor/blob/0d13b98bd00faedd1da3e98aac0cfd573f32cbd0/lib/Controller/FileHandlingController.php#L87