### PR TITLE
fix regression: typo s/x-pearl/x-perl/

### DIFF
--- a/js/supported_mimetypes.json
+++ b/js/supported_mimetypes.json
@@ -7,7 +7,7 @@
   "application/x-empty",
   "application/x-msdos-program",
   "application/x-php",
-  "application/x-pearl",
+  "application/x-perl",
   "application/x-text",
   "application/yaml"
 ]


### PR DESCRIPTION
It seems that this has been fixed before in Pull Request #98 

At the moment in my Nextcloud installation the browser always prompts me to download the .pl file instead of opening it in the editor.