### PR TITLE
fix regression: typo s/x-pearl/x-perl/

### DIFF
--- a/js/supported_mimetypes.json
+++ b/js/supported_mimetypes.json
@@ -7,7 +7,7 @@
   "application/x-empty",
   "application/x-msdos-program",
   "application/x-php",
-  "application/x-pearl",
+  "application/x-perl",
   "application/x-text",
   "application/yaml"
 ]


### PR DESCRIPTION
It seems that this has been fixed before in Pull Request 98

https://github.com/nextcloud/files_texteditor/pull/98
Signed-off-by: Andreas Boesen <Happy86@users.noreply.github.com>