### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -424,8 +424,8 @@ export const Texteditor = {
 		$('#editor_close').on('click', _.bind(this._onCloseTrigger, this));
 		$(window).resize(Texteditor.setFilenameMaxLength);
 		window.onpopstate = function () {
-			var hash = location.hash.substr(1);
-			if (hash.substr(0, 6) !== 'editor') {
+			var hash = location.hash.slice(1);
+			if (hash.slice(0, 6) !== 'editor') {
 				this._onCloseTrigger();
 			}
 		}.bind(this);

--- a/js/public-share.js
+++ b/js/public-share.js
@@ -66,7 +66,7 @@ $(document).ready(function(){
 				.removeClass('icon-loading');
 		});
 	} else if (isPublic &&
-			   mimetype.substr(0, mimetype.indexOf('/')) === 'text') {
+			   mimetype.substring(0, mimetype.indexOf('/')) === 'text') {
 		// Based on default text previews from "files_sharing/js/public.js", but
 		// using the public endpoint from files_texteditor for better character
 		// encoding support.


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.