### PR TITLE
Bump max supported version.

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -7,7 +7,7 @@
 	<description>This application enables Nextcloud users to open, save and edit text files in the web browser. If enabled, an entry called "Text file" in the "New" button menu at the top of the web browser appears. When clicked, a new text file opens in the browser and the file can be saved into the current Nextcloud directory. Further, when a text file is clicked in the web browser, it will be opened and editable. If the privileges allow, a user can also edit shared files and save these changes back into the web browser.
 More information is available in the text editor documentation.
 	</description>
-	<version>2.15.1</version>
+	<version>2.15.2</version>
 	<licence>agpl</licence>
 	<author>Tom Needham, Björn Schießle</author>
 	<namespace>FilesTextEditor</namespace>
@@ -16,6 +16,6 @@ More information is available in the text editor documentation.
 	<bugs>https://github.com/nextcloud/files_texteditor/issues</bugs>
 	<repository type="git">https://github.com/nextcloud/files_texteditor.git</repository>
 	<dependencies>
-		<nextcloud min-version="24" max-version="27" />
+		<nextcloud min-version="24" max-version="28" />
 	</dependencies>
 </info>


### PR DESCRIPTION
I submitted a similar PR for 2.15.1. See #742. Various tests were added at that time by @icewind1991. I tried to review those changes to see if there was anything I would need to add but I did not see anything and could not tell otherwise. I had copied the original PR from a prior version bump commit, and am simply doing the same here. I am just trying to get the dashboard not to complain about it being incompatible.